### PR TITLE
Added functionality to provide window height in lines

### DIFF
--- a/src/gnatcoll-terminal.adb
+++ b/src/gnatcoll-terminal.adb
@@ -435,7 +435,7 @@ package body GNATCOLL.Terminal is
 
 
    -----------------------------------------
-   -- Get_Lines (fastrgv addendum 9oct23) --
+   -- Get_Lines --
    -----------------------------------------
 
    function Get_Lines (Self : Terminal_Info) return Integer is

--- a/src/gnatcoll-terminal.adb
+++ b/src/gnatcoll-terminal.adb
@@ -432,4 +432,22 @@ package body GNATCOLL.Terminal is
          return Internal (Boolean'Pos (Self.FD = Stderr));
       end if;
    end Get_Width;
+
+
+   -----------------------------------------
+   -- Get_Lines (fastrgv addendum 9oct23) --
+   -----------------------------------------
+
+   function Get_Lines (Self : Terminal_Info) return Integer is
+      function Internal (Stderr : Integer) return Integer;
+      pragma Import (C, Internal, "gnatcoll_terminal_lines");
+   begin
+      if Self.FD = File or else Self.Colors = Unsupported then
+         return -1;
+      else
+         return Internal (Boolean'Pos (Self.FD = Stderr));
+      end if;
+   end Get_Lines;
+
+
 end GNATCOLL.Terminal;

--- a/src/gnatcoll-terminal.ads
+++ b/src/gnatcoll-terminal.ads
@@ -140,7 +140,7 @@ package GNATCOLL.Terminal is
    --  Return the width of the terminal, or -1 if that width is either
    --  unknown or does not apply (as is the case for files for instance).
 
---fastrgv addendum 9oct23:
+
    function Get_Lines (Self : Terminal_Info) return Integer;
    --  Return the height of the terminal, or -1 if that height is either
    --  unknown or does not apply (as is the case for files for instance).

--- a/src/gnatcoll-terminal.ads
+++ b/src/gnatcoll-terminal.ads
@@ -140,6 +140,12 @@ package GNATCOLL.Terminal is
    --  Return the width of the terminal, or -1 if that width is either
    --  unknown or does not apply (as is the case for files for instance).
 
+--fastrgv addendum 9oct23:
+   function Get_Lines (Self : Terminal_Info) return Integer;
+   --  Return the height of the terminal, or -1 if that height is either
+   --  unknown or does not apply (as is the case for files for instance).
+
+
    -----------
    -- Utils --
    -----------

--- a/src/terminals.c
+++ b/src/terminals.c
@@ -135,7 +135,6 @@ int gnatcoll_terminal_width(int forStderr) {
 
 
 
-// fastrgv addendum (9oct23):
 int gnatcoll_terminal_lines(int forStderr) {
 #ifdef _WIN32  // MsWin
    const HANDLE handle =


### PR DESCRIPTION

I needed to extend "terminals.c" (and gnatcoll-terminal) to detect the number of lines in a window,
(and NOT the buffer size.) 

I have tested the 3 attached modules on Windows 10, OSX, and linux.

The style is identical to "gnatcoll_terminal_width". The changed versions are used in some of my terminal games on github, eg: RetroArcade.

Moreover, the original terminal_width was changed to distinguish it from "buffer-width".